### PR TITLE
Allow command line arguments for fortran TimingAccuracy benchmarks

### DIFF
--- a/examples/fortran/TimingAccuracy/TimingAccuracyDH.f95
+++ b/examples/fortran/TimingAccuracy/TimingAccuracyDH.f95
@@ -16,7 +16,7 @@ Program TimingAccuracyDH
     implicit none
 
     integer(int32), parameter :: maxdeg = 2800
-    character(200) :: outfile1, outfile2, outfile3, outfile4, outfile
+    character(200) :: outfile1, outfile2, outfile3, outfile4, outfile, infile
     real(dp), allocatable :: cilm(:,:,:), cilm2(:,:,:), griddh(:,:)
     real(dp) :: maxerror, err1, err2, beta, rms, timein(3), timeout(3)
     integer(int32) :: lmax, l, m, seed, n, sampling, lmaxout, astat(3)
@@ -32,11 +32,20 @@ Program TimingAccuracyDH
     end if
 
     sampling = 1
-    print*, "Value of beta for power law Sff = l^(-beta) > "
-    read(*,*) beta
 
-    print*, "output file name > "
-    read(*,*) outfile
+    ! A data input file may be passed as the first argument. Otherwise prompt for required settings.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+        open(unit=20, file=infile, action="read")
+        read(20,*) beta, outfile
+        close(20)
+    else
+        print*, "Value of beta for power law Sff = l^(-beta) > "
+        read(*,*) beta
+
+        print*, "output file name > "
+        read(*,*) outfile
+    end if
 
     outfile1 = trim(outfile) // ".timef"
     outfile2 = trim(outfile) // ".timei"

--- a/examples/fortran/TimingAccuracy/TimingAccuracyDHC.f95
+++ b/examples/fortran/TimingAccuracy/TimingAccuracyDHC.f95
@@ -16,7 +16,7 @@ Program TimingAccuracyDHC
     implicit none
 
     integer(int32), parameter :: maxdeg = 2800
-    character(200) :: outfile1, outfile2, outfile3, outfile4, outfile
+    character(200) :: outfile1, outfile2, outfile3, outfile4, outfile, infile
     complex(dp), allocatable :: cilm(:,:,:), cilm2(:,:,:), griddh(:,:)
     real(dp) :: maxerror, err1, err2, beta, rms, timein(3), timeout(3)
     integer(int32) :: lmax, l, m, seed, n, sampling, lmaxout, astat(3)
@@ -32,11 +32,20 @@ Program TimingAccuracyDHC
     end if
 
     sampling = 1
-    print*, "Value of beta for power law Sff = l^(-beta) > "
-    read(*,*) beta
 
-    print*, "output file name > "
-    read(*,*) outfile
+    ! A data input file may be passed as the first argument. Otherwise prompt for required settings.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+        open(unit=20, file=infile, action="read")
+        read(20,*) beta, outfile
+        close(20)
+    else
+        print*, "Value of beta for power law Sff = l^(-beta) > "
+        read(*,*) beta
+
+        print*, "output file name > "
+        read(*,*) outfile
+    end if
 
     outfile1 = trim(outfile) // ".timef"
     outfile2 = trim(outfile) // ".timei"

--- a/examples/fortran/TimingAccuracy/TimingAccuracyGLQ.f95
+++ b/examples/fortran/TimingAccuracy/TimingAccuracyGLQ.f95
@@ -16,7 +16,7 @@ Program TimingAccuracyGLQ
     implicit none
 
     integer(int32), parameter :: maxdeg = 2800
-    character(200) :: outfile1, outfile2, outfile3, outfile4, outfile
+    character(200) :: outfile1, outfile2, outfile3, outfile4, outfile, infile
     real(dp), allocatable :: cilm(:,:,:), cilm2(:,:,:), zero(:), &
                              gridglq(:,:), w(:)
     real(dp) :: maxerror, err1, err2, beta, rms, timein(3), timeout(3)
@@ -34,11 +34,19 @@ Program TimingAccuracyGLQ
         stop
     end if
 
-    print*, "Value of beta for power law Sff = l^(-beta) > "
-    read(*,*) beta
+    ! A data input file may be passed as the first argument. Otherwise prompt for required settings.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+        open(unit=20, file=infile, action="read")
+        read(20,*) beta, outfile
+        close(20)
+    else
+        print*, "Value of beta for power law Sff = l^(-beta) > "
+        read(*,*) beta
 
-    print*, "output file name > "
-    read(*,*) outfile
+        print*, "output file name > "
+        read(*,*) outfile
+    end if
 
     outfile1 = trim(outfile) // ".timef"
     outfile2 = trim(outfile) // ".timei"

--- a/examples/fortran/TimingAccuracy/TimingAccuracyGLQC.f95
+++ b/examples/fortran/TimingAccuracy/TimingAccuracyGLQC.f95
@@ -16,7 +16,7 @@ Program TimingAccuracyGLQC
     implicit none
 
     integer(int32), parameter :: maxdeg = 2800
-    character(200) :: outfile1, outfile2, outfile3, outfile4, outfile
+    character(200) :: outfile1, outfile2, outfile3, outfile4, outfile, infile
     complex(dp), allocatable :: cilm(:,:,:), cilm2(:,:,:), gridglq(:,:)
     real(dp), allocatable :: zero(:), w(:)
     real(dp) :: maxerror, err1, err2, beta, rms, timein(3), timeout(3)
@@ -34,11 +34,19 @@ Program TimingAccuracyGLQC
         stop
     end if
 
-    print*, "Value of beta for power law Sff = l^(-beta) > "
-    read(*,*) beta
+    ! A data input file may be passed as the first argument. Otherwise prompt for required settings.
+    if (command_argument_count() > 0) then
+        call get_command_argument(1, infile)
+        open(unit=20, file=infile, action="read")
+        read(20,*) beta, outfile
+        close(20)
+    else
+        print*, "Value of beta for power law Sff = l^(-beta) > "
+        read(*,*) beta
 
-    print*, "output file name > "
-    read(*,*) outfile
+        print*, "output file name > "
+        read(*,*) outfile
+    end if
 
     outfile1 = trim(outfile) // ".timef"
     outfile2 = trim(outfile) // ".timei"

--- a/examples/fortran/TimingAccuracy/meson.build
+++ b/examples/fortran/TimingAccuracy/meson.build
@@ -26,5 +26,6 @@ foreach name, args : BENCHS
     timing_tests[test_name],
     args: [
       meson.current_source_dir() / input,
-    ])
+    ],
+    timeout: 0)
 endforeach


### PR DESCRIPTION
This PR fixes the Fortran benchmark function for the new meson implementation (https://github.com/SHTOOLS/SHTOOLS/pull/380).

* Modified the fortran sources to allow command line arguments for the TimingAccuracy routines.
* Added "timeout: 0" to the meson benchmark, as each test takes longer than 30 seconds.
